### PR TITLE
Added method to handle remote keyevents to show controls on any keypress

### DIFF
--- a/src/android/Player.java
+++ b/src/android/Player.java
@@ -92,6 +92,10 @@ public class Player {
         public boolean onKey(DialogInterface dialog, int keyCode, KeyEvent event) {
             JSONObject payload = Payload.keyEvent(event);
             new CallbackResponse(Player.this.callbackContext).send(PluginResult.Status.OK, payload, true);
+            
+            //Added method to handle remote key events to show controls on any key event
+            exoView.showController();
+            
             return false;
         }
     };


### PR DESCRIPTION

Added method to handle remote key events to show player controls on any remote key press. Now is able to work properly in TV platform showing the controls and hiding again after 5 sec.